### PR TITLE
Simpler types using satisfies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Note the presence of the `mapper` argument serves as a utility the developer to 
 Here are a couple simple examples of `Profile` objects
 
 ```ts
+// example using the Profile type with generics
 export const numberToString: Profile<'number', number, 'string', string> = {
   sourceKey: 'number',
   destinationKey: 'string',
@@ -35,13 +36,14 @@ export const numberToString: Profile<'number', number, 'string', string> = {
   },
 }
 
-export const numberToDate: Profile<'number', number, 'Date', Date> = {
+// example using the profile type with as const satisfies
+export const numberToDate = {
   sourceKey: 'number',
   destinationKey: 'Date',
   map: (source) => {
     return new Date(source)
   },
-}
+} as const satisfies Profile
 ```
 
 The mapper will use the keys you define to provide type safety when calling map.

--- a/src/createMapper.ts
+++ b/src/createMapper.ts
@@ -1,6 +1,6 @@
-import { AnyProfile, Mapper } from '@/types'
+import { Profile, Mapper } from '@/types'
 
-export function createMapper<T extends AnyProfile>(profiles: T[]): Mapper<T> {
+export function createMapper<T extends Profile>(profiles: T[]): Mapper<T> {
 
   const mapper: Mapper<T> = {
     map: (sourceKey, source, destinationKey) => {

--- a/src/types/mapper.ts
+++ b/src/types/mapper.ts
@@ -1,16 +1,6 @@
-import { AnyProfile, ExtractSourceKeys, ExtractSources, ExtractDestinationKeys, ExtractDestinations } from '@/types/profile'
+import { Profile, ProfileDestination, ProfileSource } from '@/types/profile'
 
-export type Mapper<T extends AnyProfile> = {
-  map: <
-    TSourceKey extends ExtractSourceKeys<T>,
-    TSource extends ExtractSources<T, TSourceKey>,
-    TDestinationKey extends ExtractDestinationKeys<T, TSourceKey>,
-    TDestination extends ExtractDestinations<T, TSourceKey, TDestinationKey>
-  > (sourceKey: TSourceKey, source: TSource, destinationKey: TDestinationKey) => TDestination,
-  mapMany: <
-    TSourceKey extends ExtractSourceKeys<T>,
-    TSource extends ExtractSources<T, TSourceKey>,
-    TDestinationKey extends ExtractDestinationKeys<T, TSourceKey>,
-    TDestination extends ExtractDestinations<T, TSourceKey, TDestinationKey>
-  > (sourceKey: TSourceKey, sourceArray: TSource[], destinationKey: TDestinationKey) => TDestination[],
+export type Mapper<T extends Profile> = {
+  map: (sourceKey: T['sourceKey'], source: ProfileSource<T>, destinationKey: T['destinationKey']) => ProfileDestination<T>,
+  mapMany: (sourceKey: T['sourceKey'], sourceArray: ProfileSource<T>[], destinationKey: T['destinationKey']) => ProfileDestination<T>[],
 }

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -5,23 +5,11 @@ type AnyMapper = {
   mapMany: (sourceKey: any, sourceArray: any[], destinationKey: any) => any[],
 }
 
-export interface Profile<TSourceKey extends string, TSource, TDestinationKey extends string, TDestination> {
-  sourceKey: TSourceKey,
-  destinationKey: TDestinationKey,
-  map: (source: TSource, mapper: AnyMapper) => TDestination,
+export type Profile<TSource = any, TDestination = any> = {
+  sourceKey: string,
+  destinationKey: string,
+  map: (source: TSource, mapper: AnyMapper) => TDestination
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyProfile = Profile<string, any, string, any>
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ExtractSourceKeys<TProfile> = TProfile extends Profile<infer TSourceKey, any, any, any> ? TSourceKey : never
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ExtractSources<TProfile, TKey extends ExtractSourceKeys<TProfile>> = TProfile extends Profile<TKey, infer TSource, any, any> ? TSource : never
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ExtractDestinationKeys<TProfile, TSourceKey extends ExtractSourceKeys<TProfile>> = TProfile extends Profile<TSourceKey, any, infer TDestinationKey, any> ? TDestinationKey : never
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ExtractDestinations<TProfile, TSourceKey extends ExtractSourceKeys<TProfile>, TDestinationKey extends ExtractDestinationKeys<TProfile, TSourceKey>> = TProfile extends Profile<TSourceKey, any, TDestinationKey, infer TDestination> ? TDestination : never
+export type ProfileSource<TProfile extends Profile> = Parameters<TProfile['map']>[0]
+export type ProfileDestination<TProfile extends Profile> = ReturnType<TProfile['map']>

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -5,10 +5,11 @@ type AnyMapper = {
   mapMany: (sourceKey: any, sourceArray: any[], destinationKey: any) => any[],
 }
 
-export type Profile<TSource = any, TDestination = any> = {
-  sourceKey: string,
-  destinationKey: string,
-  map: (source: TSource, mapper: AnyMapper) => TDestination
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Profile<TSourceKey = string, TSource = any, TDestinationKey = string, TDestination = any> = {
+  sourceKey: TSourceKey,
+  destinationKey: TDestinationKey,
+  map: (source: TSource, mapper: AnyMapper) => TDestination,
 }
 
 export type ProfileSource<TProfile extends Profile> = Parameters<TProfile['map']>[0]


### PR DESCRIPTION
# Description
Introduces simpler types for Profile. This enables a pattern for defining to use `as const` and `satisfies` keywords to eliminate duplication of keys and types for the source and destination. 

Before
```typescript
export const numberToString: Profile<'number', number, 'string', string> = {
  sourceKey: 'number',
  destinationKey: 'string',
  map: (source) => {
    return source.toString()
  },
}
```

After
```typescript
export const numberToString = {
  sourceKey: 'number',
  destinationKey: 'string',
  map: (source: number) => {
    return source.toString()
  },
} as const satisfies Profile
```

I believe everything should work exactly the same. The `map` and `mapMany` functions had the correct types from my testing.