### PR TITLE
Support `satisfies Profile` and simplify nested mappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,32 +16,24 @@ mapper.map('source-key', source, 'destination-key')
 
 Each profile defines a value for `sourceKey` and `destinationKey`. These keys must extend `string` and should be unique, beyond that the choice is irrelevant to the function of the mapper.
 
-The heart of the profile is the `map` function, which has the following contract
-
-```ts
-map: (source: TSource, mapper: Mapper) => TDestination
-```
-
-Note the presence of the `mapper` argument serves as a utility the developer to nest profiles (read more about nesting profiles below).
-
 Here are a couple simple examples of `Profile` objects
 
 ```ts
-export const numberToString: Profile<'number', number, 'string', string> = {
+export const numberToString = {
   sourceKey: 'number',
   destinationKey: 'string',
   map: (source) => {
     return source.toString()
   },
-}
+} as const satisfies Profile
 
-export const numberToDate: Profile<'number', number, 'Date', Date> = {
+export const numberToDate = {
   sourceKey: 'number',
   destinationKey: 'Date',
   map: (source) => {
     return new Date(source)
   },
-}
+} as const satisfies Profile
 ```
 
 The mapper will use the keys you define to provide type safety when calling map.

--- a/src/createMapper.ts
+++ b/src/createMapper.ts
@@ -1,6 +1,6 @@
-import { AnyProfile, Mapper } from '@/types'
+import { Mapper, Profile } from '@/types'
 
-export function createMapper<T extends AnyProfile>(profiles: T[]): Mapper<T> {
+export function createMapper<T extends Profile>(profiles: T[]): Mapper<T> {
 
   const mapper: Mapper<T> = {
     map: (sourceKey, source, destinationKey) => {
@@ -10,7 +10,7 @@ export function createMapper<T extends AnyProfile>(profiles: T[]): Mapper<T> {
         throw 'Mapping profile not found'
       }
 
-      return profile.map(source, mapper)
+      return profile.map(source)
     },
     mapMany: (sourceKey, sourceArray, destinationKey) => {
       return sourceArray.map(source => mapper.map(sourceKey, source, destinationKey))

--- a/src/types/mapper.ts
+++ b/src/types/mapper.ts
@@ -1,6 +1,6 @@
-import { AnyProfile, ExtractSourceKeys, ExtractSources, ExtractDestinationKeys, ExtractDestinations } from '@/types/profile'
+import { ExtractSourceKeys, ExtractSources, ExtractDestinationKeys, ExtractDestinations, Profile } from '@/types/profile'
 
-export type Mapper<T extends AnyProfile> = {
+export type Mapper<T extends Profile> = {
   map: <
     TSourceKey extends ExtractSourceKeys<T>,
     TSource extends ExtractSources<T, TSourceKey>,

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,27 +1,18 @@
-type AnyMapper = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  map: (sourceKey: any, source: any, destinationKey: any) => any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  mapMany: (sourceKey: any, sourceArray: any[], destinationKey: any) => any[],
-}
-
-export interface Profile<TSourceKey extends string, TSource, TDestinationKey extends string, TDestination> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface Profile<TSourceKey extends string = string, TSource = any, TDestinationKey extends string = string, TDestination = any> {
   sourceKey: TSourceKey,
   destinationKey: TDestinationKey,
-  map: (source: TSource, mapper: AnyMapper) => TDestination,
+  map: (source: TSource) => TDestination,
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyProfile = Profile<string, any, string, any>
+export type ExtractSourceKeys<TProfile> = TProfile extends Profile<infer TSourceKey, any, any> ? TSourceKey : never
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ExtractSourceKeys<TProfile> = TProfile extends Profile<infer TSourceKey, any, any, any> ? TSourceKey : never
+export type ExtractSources<TProfile, TKey extends ExtractSourceKeys<TProfile>> = TProfile extends Profile<TKey, infer TSource, any> ? TSource : never
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ExtractSources<TProfile, TKey extends ExtractSourceKeys<TProfile>> = TProfile extends Profile<TKey, infer TSource, any, any> ? TSource : never
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ExtractDestinationKeys<TProfile, TSourceKey extends ExtractSourceKeys<TProfile>> = TProfile extends Profile<TSourceKey, any, infer TDestinationKey, any> ? TDestinationKey : never
+export type ExtractDestinationKeys<TProfile, TSourceKey extends ExtractSourceKeys<TProfile>> = TProfile extends Profile<TSourceKey, any, infer TDestinationKey> ? TDestinationKey : never
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ExtractDestinations<TProfile, TSourceKey extends ExtractSourceKeys<TProfile>, TDestinationKey extends ExtractDestinationKeys<TProfile, TSourceKey>> = TProfile extends Profile<TSourceKey, any, TDestinationKey, infer TDestination> ? TDestination : never


### PR DESCRIPTION
# Description
Adds default values to the generics accepted by `Profile` to support using `as const satisfies Profile` when defining profiles. Also removes passing the mapper as the second argument of `map`. Since `map` is a function you can reference the mapper directly inside by just importing the mapper. 